### PR TITLE
Store preload promise on itself

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,8 +22,8 @@ export default class PreloadPlugin extends Plugin {
 		swup.preloadPages = this.preloadPages;
 
 		// replace page-fetch promise handler with custom method
-		this.originalSwupGetPageFetchPromise = swup.getPageFetchPromise.bind(swup);
-		swup.getPageFetchPromise = this.getPreloadedPageFetchPromise.bind(this);
+		this.originalSwupFetchPage = swup.fetchPage.bind(swup);
+		swup.fetchPage = this.fetchPreloadedPage.bind(this);
 
 		// register mouseenter handler
 		swup.delegatedListeners.mouseenter = swup.delegateEvent(
@@ -66,9 +66,9 @@ export default class PreloadPlugin extends Plugin {
 		swup.preloadPage = null;
 		swup.preloadPages = null;
 
-		if (this.originalSwupGetPageFetchPromise) {
-			swup.getPageFetchPromise = this.originalSwupGetPageFetchPromise;
-			this.originalSwupGetPageFetchPromise = null;
+		if (this.originalSwupFetchPage) {
+			swup.fetchPage = this.originalSwupFetchPage;
+			this.originalSwupFetchPage = null;
 		}
 
 		swup.delegatedListeners.mouseenter.destroy();
@@ -178,7 +178,7 @@ export default class PreloadPlugin extends Plugin {
 		});
 	};
 
-	getPreloadedPageFetchPromise(data) {
+	fetchPreloadedPage(data) {
 		const { url } = data;
 
 		if (this.preloadPromise && this.preloadPromise.url === url) {

--- a/src/index.js
+++ b/src/index.js
@@ -126,10 +126,10 @@ export default class PreloadPlugin extends Plugin {
 		this.preloadPromise = this.preloadPage(url);
 		this.preloadPromise.url = url;
 		this.preloadPromise
-		.catch(() => {})
-		.finally(() => {
-			this.preloadPromise = null;
-		});
+			.catch(() => {})
+			.finally(() => {
+				this.preloadPromise = null;
+			});
 	}
 
 	preloadPage = (pageUrl) => {
@@ -163,10 +163,10 @@ export default class PreloadPlugin extends Plugin {
 				}
 
 				// Finally, prepare the page, store it in the cache, trigger an event and resolve
-				page.url = url;
-				swup.cache.cacheUrl(page);
+				const cacheablePageData = { ...page, url };
+				swup.cache.cacheUrl(cacheablePageData);
 				swup.triggerEvent('pagePreloaded');
-				resolve(page);
+				resolve(cacheablePageData);
 			});
 		});
 	};
@@ -184,7 +184,7 @@ export default class PreloadPlugin extends Plugin {
 		if (this.preloadPromise && this.preloadPromise.url === url) {
 			return this.preloadPromise;
 		} else {
-			return this.preloadPage(data);
+			return this.originalSwupFetchPage(data);
 		}
 	}
 }


### PR DESCRIPTION
**Description**

- Swup will stop having a preloadPromise property (see [PR #581](https://github.com/swup/swup/pull/581))
- Store the current promise on the plugin instance
- Overwrite swup's `fetchPage` method to return preload promise if required

**Checks**

- [x] The PR is submitted to the `next` branch
- [x] The code was linted before pushing (`npm run lint`)
