### PR TITLE
Allow multiple concurrent preloads when hovering links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,9 +36,11 @@ const swup = new Swup({
 ```
 ## Options
 
-### maxConcurrentPreloads
+### throttle
 
-How many concurrent preloads should be allowed when rapidly hovering over multiple links. Decrease this to save server ressources.
+Type: `Number`, Default: `5`
+
+The *concurrency limit* for simultaneous requests when hovering links on pointer devices.
 
 ## Changes of the swup instance
 

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 Adds preloading support to [swup](https://github.com/swup/swup):
 
 - Links with a `[data-swup-preload]` attribute will be preloaded automatically
-- Hovering a link on pointer devices will preload that link's URL, speeding up load time by a few 100ms
+- Hovering a link on pointer devices will preload that link's URL, speeding up load time by a few 100ms. To save server resources, the number of simultaneous preload requests is limited to 5 by default.
 - Touch devices will instead preload links at the start of touch events, giving a ~80ms speed-up
 - If there is already a preload running, the plugin won't start another one. This saves resources on the server.
 
@@ -34,6 +34,11 @@ const swup = new Swup({
   plugins: [new SwupPreloadPlugin()]
 });
 ```
+## Options
+
+### maxConcurrentPreloads
+
+How many concurrent preloads should be allowed when rapidly hovering over multiple links. Decrease this to save server ressources.
 
 ## Changes of the swup instance
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,8 @@ export default class PreloadPlugin extends Plugin {
 
 	requires = { swup: '>=3.0.0' };
 
-	preloadPromise = null;
+	maxConcurrentPreloads = 5;
+	preloadPromises = new Map();
 
 	mount() {
 		const swup = this.swup;
@@ -59,7 +60,7 @@ export default class PreloadPlugin extends Plugin {
 			return;
 		}
 
-		this.preloadPromise = null;
+		this.preloadPromises = null;
 
 		swup._handlers.pagePreloaded = null;
 		swup._handlers.hoverLink = null;
@@ -122,15 +123,19 @@ export default class PreloadPlugin extends Plugin {
 		if (swup.cache.exists(url)) return;
 
 		// Bail early if there is already a preload running
-		if (this.preloadPromise != null) return;
+		if (this.preloadPromises.has(url)) return;
 
-		this.preloadPromise = this.preloadPage(url);
-		this.preloadPromise.url = url;
-		this.preloadPromise
+		// Bail early if there are more then the maximum allowed preloads running
+		if (this.preloadPromises.size >= this.maxConcurrentPreloads) return;
+
+		const preloadPromise = this.preloadPage(url);
+		preloadPromise.url = url;
+		preloadPromise
 			.catch(() => {})
 			.finally(() => {
-				this.preloadPromise = null;
+				this.preloadPromises.delete(url);
 			});
+		this.preloadPromises.set(url, preloadPromise);
 	}
 
 	preloadPage = (pageUrl) => {
@@ -182,10 +187,10 @@ export default class PreloadPlugin extends Plugin {
 	fetchPreloadedPage(data) {
 		const { url } = data;
 
-		if (this.preloadPromise && this.preloadPromise.url === url) {
-			return this.preloadPromise;
-		} else {
-			return this.originalSwupFetchPage(data);
-		}
+		const preloadPromise = this.preloadPromises.get(url);
+
+		if (preloadPromise != null) return preloadPromise;
+
+		return this.originalSwupFetchPage(data);
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -8,13 +8,13 @@ export default class PreloadPlugin extends Plugin {
 
 	preloadPromises = new Map();
 
-	options = {
+	defaults = {
 		throttle: 5
 	};
 
 	constructor(options = {}) {
 		super();
-		this.options = { ...this.options, ...options };
+		this.options = { ...this.defaults, ...options };
 	}
 
 	mount() {

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ export default class PreloadPlugin extends Plugin {
 	preloadPromises = new Map();
 
 	options = {
-		maxConcurrentPreloads: 5
+		throttle: 5
 	};
 
 	constructor(options = {}) {
@@ -133,8 +133,8 @@ export default class PreloadPlugin extends Plugin {
 		// Bail early if there is already a preload running
 		if (this.preloadPromises.has(url)) return;
 
-		// Bail early if there are more then the maximum allowed preloads running
-		if (this.preloadPromises.size >= this.options.maxConcurrentPreloads) return;
+		// Bail early if there are more then the maximum concurrent preloads running
+		if (this.preloadPromises.size >= this.options.throttle) return;
 
 		const preloadPromise = this.preloadPage(url);
 		preloadPromise.url = url;

--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,16 @@ export default class PreloadPlugin extends Plugin {
 
 	requires = { swup: '>=3.0.0' };
 
-	maxConcurrentPreloads = 5;
 	preloadPromises = new Map();
+
+	options = {
+		maxConcurrentPreloads: 5
+	};
+
+	constructor(options = {}) {
+		super();
+		this.options = { ...this.options, ...options };
+	}
 
 	mount() {
 		const swup = this.swup;
@@ -126,7 +134,7 @@ export default class PreloadPlugin extends Plugin {
 		if (this.preloadPromises.has(url)) return;
 
 		// Bail early if there are more then the maximum allowed preloads running
-		if (this.preloadPromises.size >= this.maxConcurrentPreloads) return;
+		if (this.preloadPromises.size >= this.options.maxConcurrentPreloads) return;
 
 		const preloadPromise = this.preloadPage(url);
 		preloadPromise.url = url;


### PR DESCRIPTION
**Description**

As described in #41 , preload plugin will currently fail to preload hovered links if there is already another hover-invoked preload running. Instead of the proposed solutions in #41, during a discussion with @gmrchk we decided to take a simpler route: 

We'll allow multiple concurrent preloads to run, so that hovering over multiple links rapidly will more likely invoke a preload for the desired page. Implemented in this PR.

I tested it manually with a throttled network connection, works great for me. Also, the implementation is quite straight forward, easy to reason about, easy to maintain.  

Right now, the maximum amount of concurrent preloads is hard-coded as `maxConcurrentPreloads = 5`. Any opinions on that? Should we make it an option? 

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] The documentation was updated as required

