### PR TITLE
Add page object to the event `pagePreloaded`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -179,7 +179,7 @@ export default class PreloadPlugin extends Plugin {
 				// Finally, prepare the page, store it in the cache, trigger an event and resolve
 				const cacheablePageData = { ...page, url };
 				swup.cache.cacheUrl(cacheablePageData);
-				swup.triggerEvent('pagePreloaded');
+				swup.triggerEvent('pagePreloaded', cacheablePageData);
 				resolve(cacheablePageData);
 			});
 		});


### PR DESCRIPTION
Fixes #64 

**Description**

From the readme:

```js
swup.on('pagePreloaded', (page) => console.log('preloaded:' page));
```

The `page` object is not being passed to the event right now. This PR fixes that.


**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch