### PR TITLE
Preload all children from parent container

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,19 @@ const swup = new Swup({
   plugins: [new SwupPreloadPlugin()]
 });
 ```
+
+Hovering a link will now automatically preload it.
+
+```html
+<a href="/about">About</a> <!-- will preload when hovering -->
+```
+
+To preload specific links, mark them with the `data-swup-preload` attribute.
+
+```html
+<a href="/about" data-swup-preload>About</a>
+```
+
 ## Options
 
 ### throttle

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,15 @@ To preload specific links, mark them with the `data-swup-preload` attribute.
 <a href="/about" data-swup-preload>About</a>
 ```
 
+To preload all links in a container, mark the container with `data-swup-preload-all`.
+
+```html
+<nav data-swup-preload-all>
+  <a href="/about">About</a>
+  <a href="/contact">Contact</a>
+</nav>
+```
+
 ## Options
 
 ### throttle

--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,7 @@ export default class PreloadPlugin extends Plugin {
 	};
 
 	preloadPages = () => {
-		queryAll('[data-swup-preload]').forEach((el) => {
+		queryAll('[data-swup-preload], [data-swup-preload-all] a').forEach((el) => {
 			if (this.shouldIgnoreVisit(el.href, { el })) return;
 			this.swup.preloadPage(el.href);
 		});


### PR DESCRIPTION
**Description**

Allow setting a preload attribute on a parent: `[data-swup-preload-all]`. This will preload all links within. Closes #54 

```html
<nav data-swup-preload-all>
  <a href="/lorem/">Lorem</a>
  <a href="/ipsum/">Ipsum</a>
  <a href="/dolor/">Dolor</a>
</nav>
```

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] The documentation was updated as required
