### PR TITLE
Remove preloading current page

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,13 @@ Type: `Number`, Default: `5`
 
 The *concurrency limit* for simultaneous requests when hovering links on pointer devices.
 
+### preloadInitialPage
+
+Type: `Boolean`, Default: `True`
+
+The reasoning behind preloading the initial page is to allow instant back-button navigation after you've navigated away from it.
+In some instances this can cause issues, so you can disable it by setting this option to `false`.
+
 ## Changes of the swup instance
 
 ### Methods

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,8 @@ export default class PreloadPlugin extends Plugin {
 	preloadPromises = new Map();
 
 	defaults = {
-		throttle: 5
+		throttle: 5,
+		preloadInitialPage: true
 	};
 
 	constructor(options = {}) {
@@ -54,8 +55,10 @@ export default class PreloadPlugin extends Plugin {
 		// initial preload of links with [data-swup-preload] attr
 		swup.preloadPages();
 
-		// do the same on every content replace
-		swup.on('contentReplaced', this.onContentReplaced);
+		// cache unmodified dom of initial/current page
+		if (this.options.preloadInitialPage) {
+            swup.preloadPage(getCurrentUrl());
+        }
 	}
 
 	unmount() {

--- a/src/index.js
+++ b/src/index.js
@@ -56,9 +56,6 @@ export default class PreloadPlugin extends Plugin {
 
 		// do the same on every content replace
 		swup.on('contentReplaced', this.onContentReplaced);
-
-		// cache unmodified dom of initial/current page
-		swup.preloadPage(getCurrentUrl());
 	}
 
 	unmount() {

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,9 @@ export default class PreloadPlugin extends Plugin {
 		// initial preload of links with [data-swup-preload] attr
 		swup.preloadPages();
 
+		// do the same on every content replace
+		swup.on('contentReplaced', this.onContentReplaced);
+
 		// cache unmodified dom of initial/current page
 		if (this.options.preloadInitialPage) {
             swup.preloadPage(getCurrentUrl());


### PR DESCRIPTION
I'm testing performance and load of my Astro site.
In Chrome, I'm watching the network tab and the page gets loaded twice every time I refresh.
I don't understand why we need to have this behavior.

My main concerns are: 

1. If the current page is already loaded, why preload it again? I think it's needed to set it for the cache, but still this seems contradictory
2. If you really want to go back to the current page it can preload that page on hover, it's fast anyway

