### PR TITLE
Pass `el.href` to `shouldIgnoreVisit`, to prevent preloading external links

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -135,10 +135,10 @@ export default class SwupPreloadPlugin extends Plugin {
 	};
 
 	preloadLink(el: HTMLAnchorElement) {
-		const { url } = Location.fromElement(el);
+		const { url, href } = Location.fromElement(el);
 
 		// Bail early if the visit should be ignored by swup
-		if (this.swup.shouldIgnoreVisit(el.href, { el })) return;
+		if (this.swup.shouldIgnoreVisit(href, { el })) return;
 
 		// Bail early if the link points to the current page
 		if (url === getCurrentUrl()) return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,6 @@ export default class SwupPreloadPlugin extends Plugin {
 		if (!this.deviceSupportsHover()) return;
 
 		const el = event.delegateTarget;
-
 		if (!(el instanceof HTMLAnchorElement)) return;
 
 		this.swup.hooks.callSync('link:hover', { el, event });
@@ -129,14 +128,17 @@ export default class SwupPreloadPlugin extends Plugin {
 		// Return early on devices that support hover
 		if (this.deviceSupportsHover()) return;
 
-		this.preloadLink(event.delegateTarget);
+		const el = event.delegateTarget;
+		if (!(el instanceof HTMLAnchorElement)) return;
+
+		this.preloadLink(el);
 	};
 
-	preloadLink(el: Element) {
+	preloadLink(el: HTMLAnchorElement) {
 		const { url } = Location.fromElement(el);
 
 		// Bail early if the visit should be ignored by swup
-		if (this.swup.shouldIgnoreVisit(url, { el })) return;
+		if (this.swup.shouldIgnoreVisit(el.href, { el })) return;
 
 		// Bail early if the link points to the current page
 		if (url === getCurrentUrl()) return;


### PR DESCRIPTION
**Description**

Fixes a regression from the port to TypeScript.

Before:

```js
const { url } = Location.fromElement(el);

// Bail early if the visit should be ignored by swup
if (this.swup.shouldIgnoreVisit(url, { el })) return; // < url is already stripped of it's origin
```

After:

```js
const { url } = Location.fromElement(el);

// Bail early if the visit should be ignored by swup
if (this.swup.shouldIgnoreVisit(el.href, { el })) return; // < Using el.href will ensure the correct origin
```

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
