### PR TITLE
Priority queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,14 @@ The plugin adds two methods for preloading pages to the swup instance.
 
 ### preload
 
-Preload a single URL. Returns a promise that resolves when the pages was preloaded.
+Preload a URL or array of URLs. Returns a Promise that resolves when the page was preloaded.
 
 ```js
 await swup.preload('/path/to/page');
+await swup.preload([
+  '/some/page',
+  '/other/page'
+]);
 ```
 
 ### preloadLinks

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The plugin adds two methods for preloading pages to the swup instance.
 
 ### preload
 
-Preload a URL or array of URLs. Returns a Promise that resolves when the page was preloaded.
+Preload a URL or array of URLs. Returns a Promise that resolves when all requested pages have been preloaded.
 
 ```js
 await swup.preload('/path/to/page');

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "3.1.2",
       "license": "MIT",
       "dependencies": {
-        "@swup/plugin": "^3.0.0"
+        "@swup/plugin": "^3.0.0",
+        "throttles": "^1.0.1"
       },
       "peerDependencies": {
         "swup": "^4.0.0"
@@ -5549,6 +5550,14 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/throttles": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/throttles/-/throttles-1.0.1.tgz",
+      "integrity": "sha512-fab7Xg+zELr9KOv4fkaBoe/b3L0GMGLd0IBSCn16GoE/Qx6/OfCr1eGNyEcDU2pUA79qQfZ8kPQWlRuok4YwTw==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tiny-glob": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "url": "https://github.com/swup/preload-plugin.git"
   },
   "dependencies": {
-    "@swup/plugin": "^3.0.0"
+    "@swup/plugin": "^3.0.0",
+    "throttles": "^1.0.1"
   },
   "peerDependencies": {
     "swup": "^4.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { default as throttles } from 'throttles/priority';
 
 declare module 'swup' {
 	export interface Swup {
-		preload?: (url: string) => Promise<PageData>;
+		preload?: (url: string) => Promise<PageData | (PageData | void)[] | void>;
 		preloadLinks?: () => void;
 	}
 	export interface HookDefinitions {
@@ -149,13 +149,13 @@ export default class SwupPreloadPlugin extends Plugin {
 		this.preload(el, { priority: true });
 	};
 
-	async preload(url: string, options?: PreloadOptions): Promise<PageData | undefined>;
+	async preload(url: string, options?: PreloadOptions): Promise<PageData | void>;
 	async preload(urls: string[], options?: PreloadOptions): Promise<PageData[]>;
-	async preload(el: HTMLAnchorElement, options?: PreloadOptions): Promise<PageData | undefined>;
+	async preload(el: HTMLAnchorElement, options?: PreloadOptions): Promise<PageData | void>;
 	async preload(
 		link: string | string[] | HTMLAnchorElement,
 		options: PreloadOptions = {}
-	): Promise<PageData | (PageData | undefined)[] | undefined> {
+	): Promise<PageData | (PageData | void)[] | void> {
 		let url: string;
 		let trigger: HTMLAnchorElement | undefined;
 		const priority = options.priority ?? false;
@@ -178,7 +178,7 @@ export default class SwupPreloadPlugin extends Plugin {
 			return;
 		}
 
-		const preloadPromise = new Promise((resolve) => {
+		const preloadPromise = new Promise<PageData | void>((resolve) => {
 			this.queue.add(() => {
 				this.performPreload(url)
 					.catch(() => {})

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,7 @@ export default class SwupPreloadPlugin extends Plugin {
 	async preload(urls: string[], options?: PreloadOptions): Promise<PageData[]>;
 	async preload(el: HTMLAnchorElement, options?: PreloadOptions): Promise<PageData | void>;
 	async preload(
-		link: string | string[] | HTMLAnchorElement,
+		input: string | string[] | HTMLAnchorElement,
 		options: PreloadOptions = {}
 	): Promise<PageData | (PageData | void)[] | void> {
 		let url: string;
@@ -161,17 +161,17 @@ export default class SwupPreloadPlugin extends Plugin {
 		const priority = options.priority ?? false;
 
 		// Allow passing in array of elements or urls
-		if (Array.isArray(link)) {
-			return Promise.all(link.map((url) => this.preload(url)));
+		if (Array.isArray(input)) {
+			return Promise.all(input.map((link) => this.preload(link)));
 		}
 		// Allow passing in an anchor element
-		else if (link instanceof HTMLAnchorElement) {
-			trigger = link;
-			({ url } = Location.fromElement(link));
+		else if (input instanceof HTMLAnchorElement) {
+			trigger = input;
+			({ url } = Location.fromElement(input));
 		}
 		// Allow passing in a url
 		else {
-			url = String(link);
+			url = String(input);
 		}
 
 		if (!this.shouldPreload(url, trigger)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,6 +191,8 @@ export default class SwupPreloadPlugin extends Plugin {
 		});
 
 		this.preloadPromises.set(url, preloadPromise);
+
+		return preloadPromise;
 	}
 
 	preloadLinks() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,7 +209,7 @@ export default class SwupPreloadPlugin extends Plugin {
 		// Should be ignored anyway?
 		if (this.swup.shouldIgnoreVisit(href, { el })) return false;
 		// Special condition for links: points to current page?
-		if (el && url === getCurrentUrl()) return false;
+		if (el && this.swup.resolveUrl(url) === this.swup.resolveUrl(getCurrentUrl())) return false;
 
 		return true;
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export default class SwupPreloadPlugin extends Plugin {
 	constructor(options: Partial<PluginOptions> = {}) {
 		super();
 		this.options = { ...this.defaults, ...options };
+		this.preload = this.preload.bind(this);
 	}
 
 	mount() {
@@ -161,11 +162,17 @@ export default class SwupPreloadPlugin extends Plugin {
 		this.preloadPromises.set(url, preloadPromise);
 	}
 
-	preload = async (url: string) => {
+	async preload(url: string): Promise<PageData>;
+	async preload(urls: string[]): Promise<PageData[]>;
+	async preload(url: string | string[]): Promise<PageData | PageData[]> {
+		if (Array.isArray(url)) {
+			return Promise.all(url.map((url) => this.preload(url)));
+		}
+
 		const page = await this.swup.fetchPage(url);
 		await this.swup.hooks.call('page:preload', { page });
 		return page;
-	};
+	}
 
 	preloadLinks = (): void => {
 		document

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,9 +178,11 @@ export default class SwupPreloadPlugin extends Plugin {
 			return;
 		}
 
-		const preloadPromise = new Promise<PageData | void>((resolve) => {
+		return new Promise<PageData | void>((resolve) => {
 			this.queue.add(() => {
-				this.performPreload(url)
+				const preloadPromise = this.performPreload(url);
+				this.preloadPromises.set(url, preloadPromise);
+				preloadPromise
 					.catch(() => {})
 					.then((page) => resolve(page))
 					.finally(() => {
@@ -189,10 +191,6 @@ export default class SwupPreloadPlugin extends Plugin {
 					});
 			}, priority);
 		});
-
-		this.preloadPromises.set(url, preloadPromise);
-
-		return preloadPromise;
 	}
 
 	preloadLinks() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "allowJs": true,                                     /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
     "outDir": "./dist",                                  /* Specify an output folder for all emitted files. */
     "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    "allowSyntheticDefaultImports": true,                /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "allowSyntheticDefaultImports": true,                /* Allow 'import x from y' when a module doesn't have a default export. */
     "strict": true,                                      /* Enable all strict type-checking options. */
     "noImplicitAny": true                                /* Enable error reporting for expressions and declarations with an implied 'any' type. */
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,9 +5,10 @@
     "moduleResolution": "Node16",                        /* Specify how TypeScript looks up a file from a given module specifier. */
     "rootDirs": ["./src"],                               /* Allow multiple folders to be treated as one when resolving modules. */
     "resolveJsonModule": true,                           /* Enable importing .json files. */
-    "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    "allowJs": true,                                     /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
     "outDir": "./dist",                                  /* Specify an output folder for all emitted files. */
     "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "allowSyntheticDefaultImports": true,                /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     "strict": true,                                      /* Enable all strict type-checking options. */
     "noImplicitAny": true                                /* Enable error reporting for expressions and declarations with an implied 'any' type. */
   }


### PR DESCRIPTION
This is in preparation for another planned feature, [preloading visible links in the viewport](https://github.com/swup/preload-plugin/issues/84).

**Description**

- Implement a high/low priority queue
- DOM links and API preloads are normal priority
- hover and touchstart preloads are high priority and will always run before other preloads
- Increases bundle size by ~150 bytes
- Tested quite extensively in a local Astro playground

**Drive-by improvements**

- Accept URLs and elements in `swup.preload`, as well as arrays of each
- Abstract preload checks into `shouldPreload` and apply them to all preload requests

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] ~~All tests are passing (`npm run test`)~~
- [ ] ~~New or updated tests are included~~
- [x] The documentation was updated as required

**Additional information**

Closes #83 
