### PR TITLE
Preload visible links in viewport

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A [swup](https://swup.js.org) plugin for preloading pages and faster navigation.
 - Links with a `data-swup-preload` attribute will be preloaded automatically
 - Hovering a link on pointer devices will preload that link's URL, speeding up load time by a few 100ms. To save server resources, the number of simultaneous preload requests is limited to 5 by default.
 - Touch devices will instead preload links at the start of touch events, giving a ~80ms speed-up
+- Optionally preload links as they become visible in the viewport
 
 ## Installation
 
@@ -36,11 +37,24 @@ const swup = new Swup({
 
 ## Preloading
 
-Hovering a link will automatically preload it.
+The plugin supports four ways of preloading links:
+
+- Hovering a link
+- Marking links to preload with a special attribute
+- Watching the viewport for links to become visible
+- Passing in a list of URLs to preload at once
+
+### Hovering links
+
+Hovering a link will automatically preload it. Enabled by default.
+
+Hovered links have higher priority than any other running preload request.
 
 ```html
 <a href="/about">About</a> <!-- will preload when hovering -->
 ```
+
+### Marking links to preload
 
 To preload specific links, mark them with the `data-swup-preload` attribute.
 
@@ -57,17 +71,58 @@ To preload all links in a container, mark the container with `data-swup-preload-
 </nav>
 ```
 
+### Preload links as they become visible
+
+Preload links as they enter the viewport. Not enabled by default.
+
+See the [preloadVisibleLinks](#preloadvisiblelinks) option for details.
+
+### Preload a list of URLs
+
+Preload specific known URLs.
+
+See the [swup.preload()](#preload) method for details.
+
 ## Options
 
 ### throttle
 
 Type: `Number`, Default: `5`
 
-The *concurrency limit* for simultaneous requests when hovering links on pointer devices.
+The *concurrency limit* for simultaneous requests when preloading.
+
+### preloadHoveredLinks
+
+Type: `Boolean`, Default: `true`
+
+Whether links should be preloaded when they are hovered.
+
+### preloadVisibleLinks
+
+Type: `Boolean` | `Object`, Default: `false`
+
+Preload links as they enter the viewport. Pass in a boolean `true` to enable with default options.
+
+```js
+new SwupPreloadPlugin({ preloadVisibleLinks: true })
+```
+
+For more control over the behavior, pass in an object. These are the default options:
+
+```js
+new SwupPreloadPlugin({
+  /** How much area of a link must be visible to preload it: 0 to 1.0 */
+  threshold: 0.2,
+  /** How long a link must be visible to preload it, in milliseconds */
+  delay: 500,
+  /** Containers to look for links in */
+  containers: ['body']
+})
+```
 
 ### preloadInitialPage
 
-Type: `Boolean`, Default: `True`
+Type: `Boolean`, Default: `true`
 
 The reasoning behind preloading the initial page is to allow instant back-button navigation after you've navigated away from it.
 In some instances this can cause issues, so you can disable it by setting this option to `false`.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ The plugin supports four ways of preloading links:
 
 Hovering a link will automatically preload it. Enabled by default.
 
-Hovered links have higher priority than any other running preload request.
+Depending on the user's device, the preload will be triggered when it is hovered with a mouse,
+touched with a finger, or focused using the keyboard. Hovered links are preloaded with higher
+priority than other running requests.
 
 ```html
 <a href="/about">About</a> <!-- will preload when hovering -->
@@ -95,13 +97,13 @@ The *concurrency limit* for simultaneous requests when preloading.
 
 Type: `Boolean`, Default: `true`
 
-Whether links should be preloaded when they are hovered.
+Preload links when they are hovered, touched or focused.
 
 ### preloadVisibleLinks
 
 Type: `Boolean` | `Object`, Default: `false`
 
-Preload links as they enter the viewport. Pass in a boolean `true` to enable with default options.
+Preload links when they enter the viewport. Pass in a boolean `true` to enable with default options.
 
 ```js
 new SwupPreloadPlugin({ preloadVisibleLinks: true })
@@ -111,12 +113,14 @@ For more control over the behavior, pass in an object. These are the default opt
 
 ```js
 new SwupPreloadPlugin({
-  /** How much area of a link must be visible to preload it: 0 to 1.0 */
-  threshold: 0.2,
-  /** How long a link must be visible to preload it, in milliseconds */
-  delay: 500,
-  /** Containers to look for links in */
-  containers: ['body']
+  preloadVisibleLinks: {
+    /** How much area of a link must be visible to preload it: 0 to 1.0 */
+    threshold: 0.2,
+    /** How long a link must be visible to preload it, in milliseconds */
+    delay: 500,
+    /** Containers to look for links in */
+    containers: ['body']
+  }
 })
 ```
 
@@ -124,8 +128,8 @@ new SwupPreloadPlugin({
 
 Type: `Boolean`, Default: `true`
 
-The reasoning behind preloading the initial page is to allow instant back-button navigation after you've navigated away from it.
-In some instances this can cause issues, so you can disable it by setting this option to `false`.
+Preload the initial page to allow instant back-button navigation after having navigated away from
+it. Disable this if it causes issues or doesn't make sense in your specific scenario.
 
 ## Methods on the swup instance
 
@@ -137,10 +141,7 @@ Preload a URL or array of URLs. Returns a Promise that resolves when all request
 
 ```js
 await swup.preload('/path/to/page');
-await swup.preload([
-  '/some/page',
-  '/other/page'
-]);
+await swup.preload(['/some/page', '/other/page']);
 ```
 
 ### preloadLinks

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "@swup/plugin": "^3.0.0",
         "throttles": "^1.0.1"
       },
+      "devDependencies": {
+        "network-information-types": "^0.1.1"
+      },
       "peerDependencies": {
         "swup": "^4.0.0"
       }
@@ -3991,6 +3994,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/network-information-types": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/network-information-types/-/network-information-types-0.1.1.tgz",
+      "integrity": "sha512-mLXNafJYOkiJB6IlF727YWssTRpXitR+tKSLyA5VAdBi3SOvLf5gtizHgxf241YHPWocnAO/fAhVrB/68tPHDw==",
+      "dev": true,
+      "peerDependencies": {
+        "typescript": ">= 3.0.0"
       }
     },
     "node_modules/node-releases": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
   "peerDependencies": {
     "swup": "^4.0.0"
   },
+  "devDependencies": {
+    "network-information-types": "^0.1.1"
+  },
   "browserslist": [
     "extends @swup/browserslist-config"
   ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export type PluginOptions = {
 	throttle: number;
 	preloadVisibleLinks: boolean;
 	preloadInitialPage: boolean;
+	preloadHoveredLinks: boolean;
 };
 
 type PreloadOptions = {
@@ -38,6 +39,7 @@ export default class SwupPreloadPlugin extends Plugin {
 		throttle: 5,
 		preloadVisibleLinks: false,
 		preloadInitialPage: true
+		preloadHoveredLinks: true,
 	};
 
 	options: PluginOptions;
@@ -87,14 +89,13 @@ export default class SwupPreloadPlugin extends Plugin {
 			{ capture: true }
 		);
 
-		// preload links with [data-swup-preload] attr after page views
-		this.on('page:view', this.onPageView);
-
 		// inject custom promise whenever a page is loaded
 		this.replace('page:load', this.onPageLoad);
 
-		// initial preload of links with [data-swup-preload] attr
-		this.preloadLinks();
+		// preload links with [data-swup-preload] attr
+		if (this.options.preloadHoveredLinks) {
+			this.preloadLinks();
+			this.on('page:view', () => this.preloadLinks());
 
 		// cache unmodified dom of initial/current page
 		if (this.options.preloadInitialPage) {
@@ -115,10 +116,6 @@ export default class SwupPreloadPlugin extends Plugin {
 
 		this.mouseEnterDelegate?.destroy();
 		this.touchStartDelegate?.destroy();
-	}
-
-	onPageView() {
-		this.preloadLinks();
 	}
 
 	onPageLoad: Handler<'page:load'> = (visit, args, defaultHandler) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ declare module 'swup' {
 
 export type PluginOptions = {
 	throttle: number;
+	preloadVisibleLinks: boolean;
 	preloadInitialPage: boolean;
 };
 
@@ -35,6 +36,7 @@ export default class SwupPreloadPlugin extends Plugin {
 
 	defaults: PluginOptions = {
 		throttle: 5,
+		preloadVisibleLinks: false,
 		preloadInitialPage: true
 	};
 
@@ -98,6 +100,11 @@ export default class SwupPreloadPlugin extends Plugin {
 		if (this.options.preloadInitialPage) {
 			this.preload(getCurrentUrl());
 		}
+
+		// preload visible links in viewport
+		if (this.options.preloadVisibleLinks) {
+			this.preloadVisibleLinks();
+		}
 	}
 
 	unmount() {
@@ -148,6 +155,10 @@ export default class SwupPreloadPlugin extends Plugin {
 
 		this.preload(el, { priority: true });
 	};
+
+	preloadVisibleLinks() {
+
+	}
 
 	async preload(url: string, options?: PreloadOptions): Promise<PageData | void>;
 	async preload(urls: string[], options?: PreloadOptions): Promise<PageData[]>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -276,7 +276,7 @@ export default class SwupPreloadPlugin extends Plugin {
 			requestIdleCallback(() => {
 				const linksToObserve: HTMLAnchorElement[] = containers.flatMap((selector) => {
 					const container = document.querySelector(selector);
-					return container ? Array.from(container.querySelectorAll<HTMLAnchorElement>(selector)) : [];
+					return container ? Array.from(container.querySelectorAll<HTMLAnchorElement>('a[href]')) : [];
 				});
 				linksToObserve
 					.filter((link) => !this.triggerWillOpenNewWindow(link))

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,7 +246,7 @@ export default class SwupPreloadPlugin extends Plugin {
 		const visibleLinks = new Set<string>();
 
 		const observer = new IntersectionObserver((entries) => {
-			entries.forEach(entry => {
+			entries.forEach((entry) => {
 				if (entry.isIntersecting) {
 					add(entry.target as HTMLAnchorElement);
 				} else {
@@ -271,11 +271,9 @@ export default class SwupPreloadPlugin extends Plugin {
 
 		const observe = () => {
 			requestIdleCallback(() => {
-				const linksToObserve: HTMLAnchorElement[] = containers.flatMap((selector) => {
-					const container = document.querySelector(selector);
-					return container ? Array.from(container.querySelectorAll<HTMLAnchorElement>('a[href]')) : [];
-				});
-				linksToObserve
+				const selector = containers.map((root) => `${root} a[href]`).join(', ');
+				const links = Array.from(document.querySelectorAll<HTMLAnchorElement>(selector));
+				links
 					.filter((link) => !this.triggerWillOpenNewWindow(link))
 					.forEach((link) => observer.observe(link));
 			});

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,12 @@ export default class SwupPreloadPlugin extends Plugin {
 		this.options = { ...this.defaults, ...otherOptions };
 
 		// Sanitize preload options
-		if (typeof preloadVisibleLinks !== 'object') {
+		if (typeof preloadVisibleLinks === 'object') {
+			this.options.preloadVisibleLinks = {
+				...this.options.preloadVisibleLinks,
+				...preloadVisibleLinks
+			};
+		} else {
 			this.options.preloadVisibleLinks.enabled = Boolean(preloadVisibleLinks);
 		}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,6 +202,8 @@ export default class SwupPreloadPlugin extends Plugin {
 	protected shouldPreload(location: string, el?: HTMLAnchorElement): boolean {
 		const { url, href } = Location.fromUrl(location);
 
+		// Network too slow?
+		if (!this.networkSupportsPreloading()) return false;
 		// Already in cache?
 		if (this.swup.cache.has(url)) return false;
 		// Already preloading?
@@ -211,6 +213,18 @@ export default class SwupPreloadPlugin extends Plugin {
 		// Special condition for links: points to current page?
 		if (el && url === getCurrentUrl()) return false;
 
+		return true;
+	}
+
+	protected networkSupportsPreloading(): boolean {
+		if (navigator.connection) {
+			if (navigator.connection.saveData) {
+				return false;
+			}
+			if (navigator.connection.effectiveType?.endsWith('2g')) {
+				return false;
+			}
+		}
 		return true;
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,6 @@ type VisibleLinkPreloadOptions = {
 
 export type PluginOptions = {
 	throttle: number;
-	timeout: number;
 	preloadInitialPage: boolean;
 	preloadHoveredLinks: boolean;
 	preloadVisibleLinks: VisibleLinkPreloadOptions;
@@ -49,13 +48,12 @@ export default class SwupPreloadPlugin extends Plugin {
 
 	defaults: PluginOptions = {
 		throttle: 5,
-		timeout: 2000,
 		preloadInitialPage: true,
 		preloadHoveredLinks: true,
 		preloadVisibleLinks: {
 			enabled: false,
-			threshold: 0,
-			delay: 0,
+			threshold: 0.2,
+			delay: 500,
 			containers: ['body']
 		}
 	};
@@ -244,7 +242,6 @@ export default class SwupPreloadPlugin extends Plugin {
 			return;
 		}
 
-		const { timeout } = this.options;
 		const { threshold, delay, containers } = this.options.preloadVisibleLinks;
 		const visibleLinks: string[] = [];
 
@@ -284,7 +281,8 @@ export default class SwupPreloadPlugin extends Plugin {
 				linksToObserve
 					.filter((link) => !this.triggerWillOpenNewWindow(link))
 					.forEach((link) => observer.observe(link));
-			}, { timeout });
+			});
+		};
 		};
 
 		observe();

--- a/src/index.ts
+++ b/src/index.ts
@@ -283,13 +283,16 @@ export default class SwupPreloadPlugin extends Plugin {
 					.forEach((link) => observer.observe(link));
 			});
 		};
+
+		const clear = () => {
+			visibleLinks.length = 0;
 		};
 
 		observe();
 
 		this.preloadObserver = {
 			stop: () => observer.disconnect(),
-			update: () => observe()
+			update: () => (clear(), observe())
 		};
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ export default class SwupPreloadPlugin extends Plugin {
 		this.mouseEnterDelegate = swup.delegateEvent(
 			swup.options.linkSelector,
 			'mouseenter',
-			this.onMouseEnter.bind(this),
+			this.onMouseEnter,
 			{ capture: true }
 		);
 
@@ -83,7 +83,7 @@ export default class SwupPreloadPlugin extends Plugin {
 		this.touchStartDelegate = swup.delegateEvent(
 			swup.options.linkSelector,
 			'touchstart',
-			this.onTouchStart.bind(this),
+			this.onTouchStart,
 			{ capture: true }
 		);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -231,9 +231,11 @@ export default class SwupPreloadPlugin extends Plugin {
 	}
 
 	preloadLinks() {
-		const selector = 'a[data-swup-preload], [data-swup-preload-all] a';
-		const links = Array.from(document.querySelectorAll<HTMLAnchorElement>(selector));
-		links.forEach((el) => this.preload(el));
+		requestIdleCallback(() => {
+			const selector = 'a[data-swup-preload], [data-swup-preload-all] a';
+			const links = Array.from(document.querySelectorAll<HTMLAnchorElement>(selector));
+			links.forEach((el) => this.preload(el));
+		});
 	}
 
 	protected preloadVisibleLinks() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,7 +243,7 @@ export default class SwupPreloadPlugin extends Plugin {
 		}
 
 		const { threshold, delay, containers } = this.options.preloadVisibleLinks;
-		const visibleLinks: string[] = [];
+		const visibleLinks = new Set<string>();
 
 		const observer = new IntersectionObserver((entries) => {
 			entries.forEach(entry => {
@@ -256,21 +256,18 @@ export default class SwupPreloadPlugin extends Plugin {
 		}, { threshold });
 
 		const add = (el: HTMLAnchorElement) => {
-			visibleLinks.push(el.href);
+			visibleLinks.add(el.href);
 			setTimeout(() => {
-				if (visibleLinks.includes(el.href)) {
+				if (visibleLinks.has(el.href)) {
 					this.preload(el.href);
 					observer.unobserve(el);
 				}
 			}, delay);
 		};
 
-		const remove = (el: HTMLAnchorElement) => {
-			const index = visibleLinks.indexOf(el.href);
-			if (index > -1) {
-				visibleLinks.splice(index);
-			}
-		};
+		const remove = (el: HTMLAnchorElement) => visibleLinks.delete(el.href);
+
+		const clear = () => visibleLinks.clear();
 
 		const observe = () => {
 			requestIdleCallback(() => {
@@ -282,10 +279,6 @@ export default class SwupPreloadPlugin extends Plugin {
 					.filter((link) => !this.triggerWillOpenNewWindow(link))
 					.forEach((link) => observer.observe(link));
 			});
-		};
-
-		const clear = () => {
-			visibleLinks.length = 0;
 		};
 
 		observe();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,9 @@
     "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     "allowSyntheticDefaultImports": true,                /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     "strict": true,                                      /* Enable all strict type-checking options. */
-    "noImplicitAny": true                                /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    "noImplicitAny": true,                               /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    "types": [
+      "./node_modules/network-information-types"
+    ]
   }
 }


### PR DESCRIPTION
**Description**

- Install an IntersectionObserver on the viewport
- Preload all links inside the viewport
- Makes more sense than quicklink: better integrated, less polyfills, less options
- Not enabled by default: added an option `preloadVisibleLinks` to enable it
- Tested and working like a charm
- Adds ~0.7K to the bundle (vs. 2K for quicklink)

**Drive-by improvements**

- Check for bad network conditions (data-saver or 2G) where supported
- Add an option `preloadHoveredLinks` to allow disabling that feature

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] ~~All tests are passing (`npm run test`)~~
- [ ] ~~New or updated tests are included~~
- [x] The documentation was updated as required

**Additional information**

Closes #84 