### PR TITLE
Properly overwrite `preloadVisibleLinks` in `PluginInitOptions`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export type PluginOptions = {
 	preloadVisibleLinks: VisibleLinkPreloadOptions;
 };
 
-export type PluginInitOptions = PluginOptions & {
+export type PluginInitOptions = Omit<PluginOptions, 'preloadVisibleLinks'> & {
 	preloadVisibleLinks: boolean | Partial<VisibleLinkPreloadOptions>;
 };
 


### PR DESCRIPTION
**Description**

When trying to test-drive the new `preloadVisibleLinks` option, I got the following TS error:

> Type 'true' is not assignable to type '(VisibleLinkPreloadOptions & (boolean | Partial<VisibleLinkPreloadOptions>)) | undefined'.

While I don't really understand the error, I was able to solve it by using `Omit<PluginOptions, 'preloadVisibleLinks'>` for the init options.


**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
