### PR TITLE
Update preload queue logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -231,15 +231,17 @@ export default class SwupPreloadPlugin extends Plugin {
 			url = String(input);
 		}
 
+		if (this.preloadPromises.has(url)) {
+			return this.preloadPromises.get(url);
+		}
+
 		if (!this.shouldPreload(url, trigger)) {
 			return;
 		}
 
 		const preloadPromise = new Promise<PageData | void>((resolve) => {
 			this.queue.add(() => {
-				const preloadPromise = this.performPreload(url);
-				this.preloadPromises.set(url, preloadPromise);
-				preloadPromise
+				this.performPreload(url)
 					.catch(() => {})
 					.then((page) => resolve(page))
 					.finally(() => {
@@ -249,6 +251,7 @@ export default class SwupPreloadPlugin extends Plugin {
 			}, priority);
 		});
 
+		this.preloadPromises.set(url, preloadPromise);
 
 		return preloadPromise;
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,13 +78,13 @@ export default class SwupPreloadPlugin extends Plugin {
 
 	options: PluginOptions;
 
-	queue: Queue;
-	preloadPromises = new Map<string, Promise<PageData | void>>();
-	preloadObserver?: { stop: () => void; update: () => void };
+	protected queue: Queue;
+	protected preloadPromises = new Map<string, Promise<PageData | void>>();
+	protected preloadObserver?: { stop: () => void; update: () => void };
 
-	mouseEnterDelegate?: DelegateEventUnsubscribe;
-	touchStartDelegate?: DelegateEventUnsubscribe;
-	focusDelegate?: DelegateEventUnsubscribe;
+	protected mouseEnterDelegate?: DelegateEventUnsubscribe;
+	protected touchStartDelegate?: DelegateEventUnsubscribe;
+	protected focusDelegate?: DelegateEventUnsubscribe;
 
 	constructor(options: Partial<PluginInitOptions> = {}) {
 		super();

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,7 +180,7 @@ export default class SwupPreloadPlugin extends Plugin {
 	/**
 	 * When hovering over a link: preload the linked page with high priority.
 	 */
-	protected onMouseEnter: DelegateEventHandler<MouseEvent, HTMLAnchorElement> = async (event) => {
+	protected onMouseEnter: DelegateEventHandler = async (event) => {
 		// Make sure mouseenter is only fired once even on links with nested html
 		if (event.target !== event.delegateTarget) return;
 
@@ -197,7 +197,7 @@ export default class SwupPreloadPlugin extends Plugin {
 	/**
 	 * When touching a link: preload the linked page with high priority.
 	 */
-	protected onTouchStart: DelegateEventHandler<TouchEvent, HTMLAnchorElement> = (event) => {
+	protected onTouchStart: DelegateEventHandler = (event) => {
 		// Return early on devices that support hover
 		if (this.deviceSupportsHover()) return;
 
@@ -210,7 +210,7 @@ export default class SwupPreloadPlugin extends Plugin {
 	/**
 	 * When focussing a link: preload the linked page with high priority.
 	 */
-	protected onFocus: DelegateEventHandler<FocusEvent, HTMLAnchorElement> = (event) => {
+	protected onFocus: DelegateEventHandler = (event) => {
 		const el = event.delegateTarget;
 		if (!(el instanceof HTMLAnchorElement)) return;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,6 @@ export default class SwupPreloadPlugin extends Plugin {
 	options: PluginOptions;
 
 	queue: Queue;
-	preloadQueue = new Map<string, Promise<unknown>>();
 	preloadPromises = new Map<string, Promise<unknown>>();
 	preloadObserver?: { stop: () => void; update: () => void };
 
@@ -156,7 +155,6 @@ export default class SwupPreloadPlugin extends Plugin {
 		this.swup.preload = undefined;
 		this.swup.preloadLinks = undefined;
 
-		this.preloadQueue.clear();
 		this.preloadPromises.clear();
 
 		this.mouseEnterDelegate?.destroy();
@@ -237,7 +235,7 @@ export default class SwupPreloadPlugin extends Plugin {
 			return;
 		}
 
-		const queuePromise = new Promise<PageData | void>((resolve) => {
+		const preloadPromise = new Promise<PageData | void>((resolve) => {
 			this.queue.add(() => {
 				const preloadPromise = this.performPreload(url);
 				this.preloadPromises.set(url, preloadPromise);
@@ -246,15 +244,13 @@ export default class SwupPreloadPlugin extends Plugin {
 					.then((page) => resolve(page))
 					.finally(() => {
 						this.queue.next();
-						this.preloadQueue.delete(url);
 						this.preloadPromises.delete(url);
 					});
 			}, priority);
 		});
 
-		this.preloadQueue.set(url, queuePromise);
 
-		return queuePromise;
+		return preloadPromise;
 	}
 
 	preloadLinks() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ export default class SwupPreloadPlugin extends Plugin {
 	options: PluginOptions;
 
 	queue: Queue;
-	preloadPromises = new Map<string, Promise<unknown>>();
+	preloadPromises = new Map<string, Promise<PageData | void>>();
 	preloadObserver?: { stop: () => void; update: () => void };
 
 	mouseEnterDelegate?: DelegateEventUnsubscribe;
@@ -207,7 +207,7 @@ export default class SwupPreloadPlugin extends Plugin {
 	};
 
 	async preload(url: string, options?: PreloadOptions): Promise<PageData | void>;
-	async preload(urls: string[], options?: PreloadOptions): Promise<PageData[]>;
+	async preload(urls: string[], options?: PreloadOptions): Promise<(PageData | void)[]>;
 	async preload(el: HTMLAnchorElement, options?: PreloadOptions): Promise<PageData | void>;
 	async preload(
 		input: string | string[] | HTMLAnchorElement,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ declare module 'swup' {
 		 * - a URL or an array of URLs
 		 * - a link element or an array of link elements
 		 */
-		preload?: (url: string) => Promise<PageData | (PageData | void)[] | void>;
+		preload?: (input: string | string[] | HTMLAnchorElement | HTMLAnchorElement[]) => Promise<PageData | (PageData | void)[] | void>;
 		/**
 		 * Preload any links on the current page manually marked for preloading.
 		 */

--- a/src/index.ts
+++ b/src/index.ts
@@ -263,7 +263,9 @@ export default class SwupPreloadPlugin extends Plugin {
 			return;
 		}
 
-		const preloadPromise = new Promise<PageData | void>((resolve) => {
+		// Queue the preload with either low or high priority
+		// The actual preload will happen when a spot in the queue is available
+		const queuedPromise = new Promise<PageData | void>((resolve) => {
 			this.queue.add(() => {
 				this.performPreload(url)
 					.catch(() => {})
@@ -275,9 +277,9 @@ export default class SwupPreloadPlugin extends Plugin {
 			}, priority);
 		});
 
-		this.preloadPromises.set(url, preloadPromise);
+		this.preloadPromises.set(url, queuedPromise);
 
-		return preloadPromise;
+		return queuedPromise;
 	}
 
 	/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -231,8 +231,10 @@ export default class SwupPreloadPlugin extends Plugin {
 	async preload(url: string, options?: PreloadOptions): Promise<PageData | void>;
 	async preload(urls: string[], options?: PreloadOptions): Promise<(PageData | void)[]>;
 	async preload(el: HTMLAnchorElement, options?: PreloadOptions): Promise<PageData | void>;
+	async preload(els: HTMLAnchorElement[], options?: PreloadOptions): Promise<(PageData | void)[]>;
+	async preload(input: string | HTMLAnchorElement, options?: PreloadOptions): Promise<PageData | void>;
 	async preload(
-		input: string | string[] | HTMLAnchorElement,
+		input: string | string[] | HTMLAnchorElement | HTMLAnchorElement[],
 		options: PreloadOptions = {}
 	): Promise<PageData | (PageData | void)[] | void> {
 		let url: string;
@@ -249,8 +251,12 @@ export default class SwupPreloadPlugin extends Plugin {
 			({ url } = Location.fromElement(input));
 		}
 		// Allow passing in a url
+		else if (typeof input === 'string') {
+			url = input;
+		}
+		// Disallow other types
 		else {
-			url = String(input);
+			return;
 		}
 
 		// Already preloading? Return existing promise

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ export default class SwupPreloadPlugin extends Plugin {
 	options: PluginOptions;
 
 	queue: Queue;
-	preloadPromises = new Map();
+	preloadPromises = new Map<string, Promise<unknown>>();
 	preloadObserver?: { stop: () => void; update: () => void };
 
 	mouseEnterDelegate?: DelegateEventUnsubscribe;
@@ -166,7 +166,7 @@ export default class SwupPreloadPlugin extends Plugin {
 
 	onPageLoad: Handler<'page:load'> = (visit, args, defaultHandler) => {
 		const { url } = visit.to;
-		if (this.preloadPromises.has(url)) {
+		if (url && this.preloadPromises.has(url)) {
 			return this.preloadPromises.get(url);
 		}
 		return defaultHandler?.(visit, args);

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,31 +125,13 @@ export default class SwupPreloadPlugin extends Plugin {
 		swup.preload = this.preload;
 		swup.preloadLinks = this.preloadLinks;
 
-		// register mouseenter handler
-		this.mouseEnterDelegate = swup.delegateEvent(
-			swup.options.linkSelector,
-			'mouseenter',
-			this.onMouseEnter,
-			{ passive: true, capture: true }
-		);
+		// Register handlers for preloading on attention: mouseenter, touchstart, focus
+		const { linkSelector: selector } = swup.options;
+		const opts = { passive: true, capture: true };
+		this.mouseEnterDelegate = swup.delegateEvent(selector, 'mouseenter', this.onMouseEnter, opts);
+		this.touchStartDelegate = swup.delegateEvent(selector, 'touchstart', this.onTouchStart, opts);
+		this.focusDelegate = swup.delegateEvent(selector, 'focus', this.onFocus, opts);
 
-		// register touchstart handler
-		this.touchStartDelegate = swup.delegateEvent(
-			swup.options.linkSelector,
-			'touchstart',
-			this.onTouchStart,
-			{ passive: true, capture: true }
-		);
-
-		// register focus handler
-		this.focusDelegate = swup.delegateEvent(
-			swup.options.linkSelector,
-			'focus',
-			this.onFocus,
-			{ passive: true, capture: true }
-		);
-
-		// inject custom promise whenever a page is loaded
 		// Inject custom promise whenever a page is loaded
 		this.replace('page:load', this.onPageLoad);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -287,7 +287,7 @@ export default class SwupPreloadPlugin extends Plugin {
 			visibleLinks.add(el.href);
 			setTimeout(() => {
 				if (visibleLinks.has(el.href)) {
-					this.preload(el.href);
+					this.preload(el);
 					observer.unobserve(el);
 				}
 			}, delay);
@@ -302,8 +302,8 @@ export default class SwupPreloadPlugin extends Plugin {
 				const selector = containers.map((root) => `${root} a[href]`).join(', ');
 				const links = Array.from(document.querySelectorAll<HTMLAnchorElement>(selector));
 				links
-					.filter((link) => !this.triggerWillOpenNewWindow(link))
-					.forEach((link) => observer.observe(link));
+					.filter((el) => !this.swup.shouldIgnoreVisit(el.href, { el }))
+					.forEach((el) => observer.observe(el));
 			});
 		};
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ export default class SwupPreloadPlugin extends Plugin {
 	options: PluginOptions;
 
 	queue: Queue;
+	preloadQueue = new Map<string, Promise<unknown>>();
 	preloadPromises = new Map<string, Promise<unknown>>();
 	preloadObserver?: { stop: () => void; update: () => void };
 
@@ -155,6 +156,7 @@ export default class SwupPreloadPlugin extends Plugin {
 		this.swup.preload = undefined;
 		this.swup.preloadLinks = undefined;
 
+		this.preloadQueue.clear();
 		this.preloadPromises.clear();
 
 		this.mouseEnterDelegate?.destroy();
@@ -235,7 +237,7 @@ export default class SwupPreloadPlugin extends Plugin {
 			return;
 		}
 
-		return new Promise<PageData | void>((resolve) => {
+		const queuePromise = new Promise<PageData | void>((resolve) => {
 			this.queue.add(() => {
 				const preloadPromise = this.performPreload(url);
 				this.preloadPromises.set(url, preloadPromise);
@@ -244,10 +246,15 @@ export default class SwupPreloadPlugin extends Plugin {
 					.then((page) => resolve(page))
 					.finally(() => {
 						this.queue.next();
+						this.preloadQueue.delete(url);
 						this.preloadPromises.delete(url);
 					});
 			}, priority);
 		});
+
+		this.preloadQueue.set(url, queuePromise);
+
+		return queuePromise;
 	}
 
 	preloadLinks() {


### PR DESCRIPTION
**Description**

- Fix an issue where links would get preloaded twice by checking existing promises early
- Improve IntersectionObserver performance by filtering links earlier

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] ~~All tests are passing (`npm run test`)~~
- [ ] ~~New or updated tests are included~~
- [ ] ~~The documentation was updated as required~~

**Additional information**

<!--
Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.
-->
