### PR TITLE
Implement keyed priority queue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "3.2.2",
       "license": "MIT",
       "dependencies": {
-        "@swup/plugin": "^3.0.0",
-        "throttles": "^1.0.1"
+        "@swup/plugin": "^3.0.0"
       },
       "devDependencies": {
         "network-information-types": "^0.1.1"
@@ -5562,14 +5561,6 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
-    "node_modules/throttles": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/throttles/-/throttles-1.0.1.tgz",
-      "integrity": "sha512-fab7Xg+zELr9KOv4fkaBoe/b3L0GMGLd0IBSCn16GoE/Qx6/OfCr1eGNyEcDU2pUA79qQfZ8kPQWlRuok4YwTw==",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/tiny-glob": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "url": "https://github.com/swup/preload-plugin.git"
   },
   "dependencies": {
-    "@swup/plugin": "^3.0.0",
-    "throttles": "^1.0.1"
+    "@swup/plugin": "^3.0.0"
   },
   "peerDependencies": {
     "swup": "^4.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import Plugin from '@swup/plugin';
 import { getCurrentUrl, Handler, Location } from 'swup';
 import type { DelegateEvent, DelegateEventHandler, DelegateEventUnsubscribe, PageData } from 'swup';
-import { default as throttles } from 'throttles/priority';
+import createQueue, { Queue } from './queue.js';
 
 declare module 'swup' {
 	export interface Swup {
@@ -54,11 +54,6 @@ type PreloadOptions = {
 	priority?: boolean;
 };
 
-type Queue = {
-	add: (fn: () => void, highPriority?: boolean) => void;
-	next: () => void;
-};
-
 export default class SwupPreloadPlugin extends Plugin {
 	name = 'SwupPreloadPlugin';
 
@@ -107,8 +102,7 @@ export default class SwupPreloadPlugin extends Plugin {
 		this.preload = this.preload.bind(this);
 
 		// Create global priority queue
-		const [add, next] = throttles(this.options.throttle);
-		this.queue = { add, next };
+		this.queue = createQueue(this.options.throttle);
 	}
 
 	mount() {

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1,0 +1,59 @@
+type QueueFunction = {
+	(): void;
+	__queued?: boolean;
+};
+
+export type Queue = {
+	add: (fn: QueueFunction, highPriority?: boolean) => void;
+	next: () => void;
+};
+
+export default function createQueue(limit: number = 1): Queue {
+	const qlow: QueueFunction[] = [];
+	const qhigh: QueueFunction[] = [];
+	let total = 0;
+	let running = 0;
+
+	function add(fn: QueueFunction, highPriority: boolean = false): void {
+		// Already added before?
+		if (fn.__queued) {
+			// Move from low to high-priority queue
+			if (highPriority) {
+				const idx = qlow.indexOf(fn);
+				if (idx >= 0) {
+					const removed = qlow.splice(idx, 1);
+					total = total - removed.length;
+				}
+			} else {
+				return;
+			}
+		}
+
+		// Mark as processed
+		fn.__queued = true;
+		// Push to queue: high or low
+		(highPriority ? qhigh : qlow).push(fn);
+		// Increment total
+		total++;
+		// Initialize queue if first item
+		if (total <= 1) {
+			run();
+		}
+	}
+
+	function next(): void {
+		running--; // make room for next
+		run();
+	}
+
+	function run(): void {
+		if (running < limit && total > 0) {
+			const fn = qhigh.shift() || qlow.shift() || (() => {});
+			fn();
+			total--;
+			running++; // is now WIP
+		}
+	}
+
+	return { add, next };
+}

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -2,20 +2,29 @@ type QueueFunction = {
 	(): unknown | Promise<unknown>;
 };
 
+/**
+ * A priority queue that runs a limited number of jobs at a time.
+ */
 export default class Queue {
+	/** The number of jobs to run at a time */
 	private limit: number;
+	/** The queue of low-priority jobs */
 	private qlow: Map<string, QueueFunction> = new Map();
+	/** The queue of high-priority jobs */
 	private qhigh: Map<string, QueueFunction> = new Map();
+	/** The list of currently running jobs */
 	private running: Set<string> = new Set();
 
 	constructor(limit: number = 1) {
 		this.limit = limit;
 	}
 
+	/** The total number of jobs in the queue */
 	get total(): number {
 		return this.qlow.size + this.qhigh.size;
 	}
 
+	/** Add a job to queue */
 	add(key: string, fn: QueueFunction, highPriority: boolean = false): void {
 		if (this.running.has(key)) return;
 
@@ -34,6 +43,7 @@ export default class Queue {
 		}
 	}
 
+	/** Run the next available job */
 	protected async run(): Promise<void> {
 		if (!this.total) return;
 		if (this.running.size >= this.limit) return;
@@ -48,6 +58,7 @@ export default class Queue {
 		}
 	}
 
+	/** Get the next available job */
 	protected next(): { key: string; fn: QueueFunction } | null {
 		return [this.qhigh, this.qlow].reduce((acc, queue) => {
 			if (!acc) {

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -58,7 +58,10 @@ export default class Queue {
 		return [this.qhigh, this.qlow].reduce((acc, queue) => {
 			if (!acc) {
 				const [key, fn] = queue.entries().next().value || [];
-				return key ? { key, fn } : acc;
+				if (key) {
+					queue.delete(key);
+					return { key, fn };
+				}
 			}
 			return acc;
 		}, null as { key: string; fn: QueueFunction } | null);


### PR DESCRIPTION
**Description**

- Re-implement throttled queue as class with keyed Maps
- Goal: key jobs by URL to allow handing out Promises
- Replace the job queue and the preloadPromises Map to a single `this.queue`

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] ~~All tests are passing (`npm run test`)~~
- [ ] ~~New or updated tests are included~~
- [ ] ~~The documentation was updated as required~~

**Additional information**

Closes #95 