### PR TITLE
Fix duplicate links not being preloaded

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -19,7 +19,7 @@ export default function createObserver({
 	callback: (el: HTMLAnchorElement) => void;
 	filter: (el: HTMLAnchorElement) => boolean;
 }): Observer {
-	const visibleLinks = new Map<string, WeakSet<HTMLAnchorElement>>();
+	const visibleLinks = new Map<string, Set<HTMLAnchorElement>>();
 
 	// Create an observer to add/remove links when they enter the viewport
 	const observer = new IntersectionObserver(
@@ -37,15 +37,15 @@ export default function createObserver({
 
 	// Preload link if it is still visible after a configurable timeout
 	const add = (el: HTMLAnchorElement) => {
-		visibleLinks.set(el.href, visibleLinks.get(el.href) ?? new WeakSet());
+		visibleLinks.set(el.href, visibleLinks.get(el.href) ?? new Set());
 		visibleLinks.get(el.href)!.add(el);
 
 		setTimeout(() => {
-			const set = visibleLinks.get(el.href);
-			if (set && set.has(el)) {
+			const links = visibleLinks.get(el.href);
+			if (links?.size) {
 				callback(el);
 				observer.unobserve(el);
-				set.delete(el);
+				links.delete(el);
 			}
 		}, delay);
 	};

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -1,4 +1,4 @@
-import { whenIdle } from "./util.js";
+import { whenIdle } from './util.js';
 
 export type Observer = {
 	start: () => void;
@@ -6,12 +6,18 @@ export type Observer = {
 	update: () => void;
 };
 
-export default function createObserver({ threshold, delay, containers, callback, filter }: {
-	threshold: number,
-	delay: number,
-	containers: string[],
-	callback: (el: HTMLAnchorElement) => void,
-	filter: (el: HTMLAnchorElement) => boolean
+export default function createObserver({
+	threshold,
+	delay,
+	containers,
+	callback,
+	filter
+}: {
+	threshold: number;
+	delay: number;
+	containers: string[];
+	callback: (el: HTMLAnchorElement) => void;
+	filter: (el: HTMLAnchorElement) => boolean;
 }): Observer {
 	const visibleLinks = new Set<string>();
 

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -37,15 +37,16 @@ export default function createObserver({
 
 	// Preload link if it is still visible after a configurable timeout
 	const add = (el: HTMLAnchorElement) => {
-		visibleLinks.set(el.href, visibleLinks.get(el.href) ?? new Set());
-		visibleLinks.get(el.href)!.add(el);
+		const elements = visibleLinks.get(el.href) ?? new Set();
+		visibleLinks.set(el.href, elements);
+		elements.add(el);
 
 		setTimeout(() => {
-			const links = visibleLinks.get(el.href);
-			if (links?.size) {
+			const elements = visibleLinks.get(el.href);
+			if (elements?.size) {
 				callback(el);
 				observer.unobserve(el);
-				links.delete(el);
+				elements.delete(el);
 			}
 		}, delay);
 	};

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -1,0 +1,63 @@
+import { whenIdle } from "./util.js";
+
+export type Observer = {
+	start: () => void;
+	stop: () => void;
+	update: () => void;
+};
+
+export default function createObserver({ threshold, delay, containers, callback, filter }: {
+	threshold: number,
+	delay: number,
+	containers: string[],
+	callback: (el: HTMLAnchorElement) => void,
+	filter: (el: HTMLAnchorElement) => boolean
+}): Observer {
+	const visibleLinks = new Set<string>();
+
+	// Create an observer to add/remove links when they enter the viewport
+	const observer = new IntersectionObserver(
+		(entries) => {
+			entries.forEach((entry) => {
+				if (entry.isIntersecting) {
+					add(entry.target as HTMLAnchorElement);
+				} else {
+					remove(entry.target as HTMLAnchorElement);
+				}
+			});
+		},
+		{ threshold }
+	);
+
+	// Preload link if it is still visible after a configurable timeout
+	const add = (el: HTMLAnchorElement) => {
+		visibleLinks.add(el.href);
+		setTimeout(() => {
+			if (visibleLinks.has(el.href)) {
+				callback(el);
+				observer.unobserve(el);
+			}
+		}, delay);
+	};
+
+	// Remove link from list of visible links
+	const remove = (el: HTMLAnchorElement) => visibleLinks.delete(el.href);
+
+	// Clear list of visible links
+	const clear = () => visibleLinks.clear();
+
+	// Scan DOM for preloadable links and start observing their visibility
+	const observe = () => {
+		whenIdle(() => {
+			const selector = containers.map((root) => `${root} a[href]`).join(', ');
+			const links = Array.from(document.querySelectorAll<HTMLAnchorElement>(selector));
+			links.filter((el) => filter(el)).forEach((el) => observer.observe(el));
+		});
+	};
+
+	return {
+		start: () => observe(),
+		stop: () => observer.disconnect(),
+		update: () => (clear(), observe())
+	};
+}

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -19,7 +19,7 @@ export default function createObserver({
 	callback: (el: HTMLAnchorElement) => void;
 	filter: (el: HTMLAnchorElement) => boolean;
 }): Observer {
-	const visibleLinks = new Map<string, Set<HTMLAnchorElement>>();
+	const visibleLinks = new Map<string, WeakSet<HTMLAnchorElement>>();
 
 	// Create an observer to add/remove links when they enter the viewport
 	const observer = new IntersectionObserver(
@@ -37,7 +37,7 @@ export default function createObserver({
 
 	// Preload link if it is still visible after a configurable timeout
 	const add = (el: HTMLAnchorElement) => {
-		visibleLinks.set(el.href, visibleLinks.get(el.href) || new Set());
+		visibleLinks.set(el.href, visibleLinks.get(el.href) ?? new WeakSet());
 		visibleLinks.get(el.href)!.add(el);
 
 		setTimeout(() => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,28 @@
+/**
+ * Check if the user's connection is configured and fast enough
+ * to preload data in the background.
+ */
+export function networkSupportsPreloading(): boolean {
+	if (navigator.connection) {
+		if (navigator.connection.saveData) {
+			return false;
+		}
+		if (navigator.connection.effectiveType?.endsWith('2g')) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/**
+ * Does this device support true hover/pointer interactions?
+ */
+export function deviceSupportsHover() {
+	return window.matchMedia('(hover: hover)').matches;
+}
+
+
+/**
+ * Safe requestIdleCallback function that falls back to setTimeout
+ */
+export const whenIdle = window.requestIdleCallback || ((cb) => setTimeout(cb, 1));

--- a/src/util.ts
+++ b/src/util.ts
@@ -21,7 +21,6 @@ export function deviceSupportsHover() {
 	return window.matchMedia('(hover: hover)').matches;
 }
 
-
 /**
  * Safe requestIdleCallback function that falls back to setTimeout
  */


### PR DESCRIPTION
**Description**

- Index visible links by href first and by element second
- Fix issue #104 where duplicate links would prevent preloading the link at all
- Tested in playground

**Drive-by improvements**

- Extract utils into separate file
- Extract observer into separate file

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] ~~The documentation was updated as required~~

**Additional information**

- Closes #104 