### PR TITLE
feat: ignore visible links

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ new SwupPreloadPlugin({
     /** How long a link must be visible to preload it, in milliseconds */
     delay: 500,
     /** Containers to look for links in */
-    containers: ['body']
+    containers: ['body'],
+    /** Callback for opting out selected elements from preloading */
+    ignore: (el) => false
   }
 })
 ```


### PR DESCRIPTION
**Description**

Adds a new option `preloadVisibleLinks.ignore` to opt out from automatic preloading for selected elements:

```js
{
	preloadVisibleLinks: {
		ignore: (el) => !!el.closest('.footer')
	},
},
```

Or:

```js
{
	preloadVisibleLinks: {
		ignore: (el) => el.pathname.startsWith('/imprint')
	},
},
```

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] The documentation was updated as required

