### PR TITLE
Fix `swup.preload` type signature

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,9 +18,7 @@ declare module 'swup' {
 		 * - a URL or an array of URLs
 		 * - a link element or an array of link elements
 		 */
-		preload?: (
-			input: string | string[] | HTMLAnchorElement | HTMLAnchorElement[]
-		) => Promise<PageData | (PageData | void)[] | void>;
+		preload?: SwupPreloadPlugin['preload'];
 		/**
 		 * Preload any links on the current page manually marked for preloading.
 		 */


### PR DESCRIPTION
**Description**

Directly use the type signature of `SwupPreloadPlugin['preload']` for  `swup.preload` augmentation

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] Tested locally in TS project
