### PR TITLE
Fix `options.preloadHoveredLinks`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.2.7] - 2023-10-20
+
+- Fix `options.preloadHoveredLinks`
+
 ## [3.2.6] - 2023-10-13
 
 - Fix `swup.preload` function signature
@@ -107,6 +111,7 @@
 
 - Initial release
 
+[3.2.7]: https://github.com/swup/preload-plugin/releases/tag/3.2.7
 [3.2.6]: https://github.com/swup/preload-plugin/releases/tag/3.2.6
 [3.2.5]: https://github.com/swup/preload-plugin/releases/tag/3.2.5
 [3.2.4]: https://github.com/swup/preload-plugin/releases/tag/3.2.4

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swup/preload-plugin",
   "amdName": "SwupPreloadPlugin",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "description": "A swup plugin for preloading pages and faster navigation",
   "type": "module",
   "source": "src/index.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,30 +133,30 @@ export default class SwupPreloadPlugin extends Plugin {
 		swup.preloadLinks = this.preloadLinks;
 
 		// Register handlers for preloading on attention: mouseenter, touchstart, focus
-		const { linkSelector: selector } = swup.options;
-		const opts = { passive: true, capture: true };
-		this.mouseEnterDelegate = swup.delegateEvent(
-			selector,
-			'mouseenter',
-			this.onMouseEnter,
-			opts
-		);
-		this.touchStartDelegate = swup.delegateEvent(
-			selector,
-			'touchstart',
-			this.onTouchStart,
-			opts
-		);
-		this.focusDelegate = swup.delegateEvent(selector, 'focus', this.onFocus, opts);
+		if (this.options.preloadHoveredLinks) {
+			const { linkSelector: selector } = swup.options;
+			const opts = { passive: true, capture: true };
+			this.mouseEnterDelegate = swup.delegateEvent(
+				selector,
+				'mouseenter',
+				this.onMouseEnter,
+				opts
+			);
+			this.touchStartDelegate = swup.delegateEvent(
+				selector,
+				'touchstart',
+				this.onTouchStart,
+				opts
+			);
+			this.focusDelegate = swup.delegateEvent(selector, 'focus', this.onFocus, opts);
+		}
 
 		// Inject custom promise whenever a page is loaded
 		this.replace('page:load', this.onPageLoad);
 
 		// Preload links with [data-swup-preload] attr
-		if (this.options.preloadHoveredLinks) {
-			this.preloadLinks();
-			this.on('page:view', () => this.preloadLinks());
-		}
+		this.preloadLinks();
+		this.on('page:view', () => this.preloadLinks());
 
 		// Preload visible links in viewport
 		if (this.options.preloadVisibleLinks.enabled) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,25 +132,6 @@ export default class SwupPreloadPlugin extends Plugin {
 		swup.preload = this.preload;
 		swup.preloadLinks = this.preloadLinks;
 
-		// Register handlers for preloading on attention: mouseenter, touchstart, focus
-		if (this.options.preloadHoveredLinks) {
-			const { linkSelector: selector } = swup.options;
-			const opts = { passive: true, capture: true };
-			this.mouseEnterDelegate = swup.delegateEvent(
-				selector,
-				'mouseenter',
-				this.onMouseEnter,
-				opts
-			);
-			this.touchStartDelegate = swup.delegateEvent(
-				selector,
-				'touchstart',
-				this.onTouchStart,
-				opts
-			);
-			this.focusDelegate = swup.delegateEvent(selector, 'focus', this.onFocus, opts);
-		}
-
 		// Inject custom promise whenever a page is loaded
 		this.replace('page:load', this.onPageLoad);
 
@@ -162,6 +143,11 @@ export default class SwupPreloadPlugin extends Plugin {
 		if (this.options.preloadVisibleLinks.enabled) {
 			this.preloadVisibleLinks();
 			this.on('page:view', () => this.preloadVisibleLinks());
+		}
+
+		// Preload links on attention
+		if (this.options.preloadHoveredLinks) {
+			this.preloadLinksOnAttention();
 		}
 
 		// Cache unmodified DOM of initial/current page
@@ -321,6 +307,32 @@ export default class SwupPreloadPlugin extends Plugin {
 			const links = Array.from(document.querySelectorAll<HTMLAnchorElement>(selector));
 			links.forEach((el) => this.preload(el));
 		});
+	}
+
+	/**
+	 * Register handlers for preloading on attention:
+	 *  - mouseenter
+	 *  - touchstart
+	 *  - focus
+	 */
+	protected preloadLinksOnAttention() {
+		const { swup } = this;
+
+		const { linkSelector: selector } = swup.options;
+		const opts = { passive: true, capture: true };
+		this.mouseEnterDelegate = swup.delegateEvent(
+			selector,
+			'mouseenter',
+			this.onMouseEnter,
+			opts
+		);
+		this.touchStartDelegate = swup.delegateEvent(
+			selector,
+			'touchstart',
+			this.onTouchStart,
+			opts
+		);
+		this.focusDelegate = swup.delegateEvent(selector, 'focus', this.onFocus, opts);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #113 

**Description**

- Moves the check for `options.preloadHoveredLinks` to the right place.
- Includes version bump and changelog update
- Reproduced and fixed the bug in a local project
- Extract handler registration to own function

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
