### PR TITLE
Support preloading SVG link elements

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -270,6 +270,9 @@ export default class SwupPreloadPlugin extends Plugin {
 			return;
 		}
 
+		// Return if no url passed in
+		if (!url) return;
+
 		// Already preloading? Return existing promise
 		if (this.preloadPromises.has(url)) {
 			return this.preloadPromises.get(url);

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,6 +22,13 @@ export function deviceSupportsHover() {
 }
 
 /**
+ * Is this element an anchor element?
+ */
+export function isAnchorElement(element: unknown): element is HTMLAnchorElement | SVGAElement {
+	return !!element && (element instanceof HTMLAnchorElement || element instanceof SVGAElement);
+}
+
+/**
  * Safe requestIdleCallback function that falls back to setTimeout
  */
 export const whenIdle = window.requestIdleCallback || ((cb) => setTimeout(cb, 1));

--- a/tests/fixtures/link-types.html
+++ b/tests/fixtures/link-types.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Link types</title>
+		<link rel="stylesheet" href="/assets/style.css" />
+	</head>
+	<body>
+		<main id="swup" class="transition-main">
+			<h1>Link types</h1>
+
+			<p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.</p>
+			<ul>
+				<li><a href="/page-1.html">Page 1</a></li>
+			</ul>
+
+			<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+				<a xlink:href="/page-2.html">
+					<text x="10" y="10" font-size="2">SVG link to page</text>
+				</a>
+			</svg>
+
+			<img src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" usemap="#imagemap" width="100" height="100" />
+			<map name="imagemap">
+					<area shape="rect" coords="0,0,100,100" href="/page-3.html" alt="Map link to page" />
+			</map>
+		</main>
+		<script src="/dist/swup.umd.js"></script>
+		<script src="/dist/index.umd.js"></script>
+		<script>
+			window._swup = new Swup({
+				linkSelector: 'a[href], a[*|href]',
+				plugins: [new SwupPreloadPlugin()]
+			});
+		</script>
+	</body>
+</html>

--- a/tests/functional/preload-plugin.spec.ts
+++ b/tests/functional/preload-plugin.spec.ts
@@ -93,6 +93,14 @@ test.describe('active links', () => {
 		await expectSwupToHaveCacheEntry(page, '/page-2.html');
 		await expectSwupToHaveCacheEntry(page, '/page-3.html');
 	});
+
+	test('preloads svg links', async ({ page }) => {
+		await page.goto('/link-types.html');
+		await waitForSwup(page);
+		await expectSwupNotToHaveCacheEntry(page, '/page-2.html');
+		await page.focus('svg a', { strict: true });
+		await expectSwupToHaveCacheEntry(page, '/page-2.html');
+	});
 });
 
 test.describe('visible links', () => {


### PR DESCRIPTION
**Description**

- Found a branch I've been using as private fork in production for a while
- Support preloading links in SVGs


**Drive-by changes**

- Return early from `swup.preload(url)` if no url is passed in (homepage still works as it should be `'/'` anyway)

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] ~~The documentation was updated as required~~