### PR TITLE
fix: don't wrongly abort preload fetch requests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -424,6 +424,7 @@ export default class SwupPreloadPlugin extends Plugin {
 			visit,
 			{ url },
 			async (visit, args) => {
+				// @ts-expect-error FetchOptions.visit is currently marked as internal
 				args.page = await this.swup.fetchPage(href, { visit });
 				return args.page;
 			}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,12 @@ import type {
 	PageData,
 	HookDefaultHandler
 } from 'swup';
-import { deviceSupportsHover, networkSupportsPreloading, whenIdle, isAnchorElement } from './util.js';
+import {
+	deviceSupportsHover,
+	networkSupportsPreloading,
+	whenIdle,
+	isAnchorElement
+} from './util.js';
 import createQueue, { Queue } from './queue.js';
 import createObserver, { Observer } from './observer.js';
 
@@ -26,7 +31,7 @@ declare module 'swup' {
 	}
 	export interface HookDefinitions {
 		'link:hover': { el: HTMLAnchorElement | SVGAElement; event: DelegateEvent };
-		'page:preload': { url: string, page?: PageData };
+		'page:preload': { url: string; page?: PageData };
 	}
 	export interface HookReturnValues {
 		'page:preload': Promise<PageData>;
@@ -414,10 +419,15 @@ export default class SwupPreloadPlugin extends Plugin {
 		// @ts-expect-error: createVisit is currently private, need to make this semi-public somehow
 		const visit = this.swup.createVisit({ to: url });
 
-		const page = await this.swup.hooks.call('page:preload', visit, { url }, async (visit, args) => {
-			args.page = await this.swup.fetchPage(href);
-			return args.page;
-		});
+		const page = await this.swup.hooks.call(
+			'page:preload',
+			visit,
+			{ url },
+			async (visit, args) => {
+				args.page = await this.swup.fetchPage(href, { visit });
+				return args.page;
+			}
+		);
 		return page;
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,6 @@ export default class SwupPreloadPlugin extends Plugin {
 		swup.hooks.create('page:preload');
 		swup.hooks.create('link:hover');
 
-		// @ts-ignore: non-matching signatures (TODO: fix properly)
 		swup.preload = this.preload;
 		swup.preloadLinks = this.preloadLinks;
 


### PR DESCRIPTION
**The problem**

Currently, all preload requests after the first `page:view` are being exited early. The reason for this is that `swup.fetchPage` falls back to swup's internal `visit` object if we don't provide a custom visit to it. It then calls the hook `fetch:request` that exits early if the visit is already done.

**The solution**

Pass the temporary visit from `performPreload`  along in the `FetchOptions` for `fetchPage`.

**Future**

- should we make the `visit` a required FetchOption so that we don't run into this again?
- should we make `FetchOptions.visit` public?

I'd like to merge this as soon as possible, we can discuss possible improvements later.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
