### PR TITLE
feat: respect data-swup-no-preload for preloadHoveredLinks/preloadVisibleLinks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -201,6 +201,7 @@ export default class SwupPreloadPlugin extends Plugin {
 
 		const el = event.delegateTarget;
 		if (!isAnchorElement(el)) return;
+		if (el.hasAttribute('data-swup-no-preload')) return;
 
 		// Create temporary visit object for link:hover hook
 		const { url: to, hash } = Location.fromElement(el);
@@ -371,11 +372,13 @@ export default class SwupPreloadPlugin extends Plugin {
 		const { threshold, delay, containers } = this.options.preloadVisibleLinks;
 		const callback = (el: AnchorElement) => this.preload(el);
 		const filter = (el: AnchorElement) => {
-			/** First, run the custom callback */
-			if (this.options.preloadVisibleLinks.ignore(el)) return false;
+			/** First, look for opt-out attribute */
+			if (el.hasAttribute('data-swup-no-preload')) return false;
 			/** Second, check if it's a valid swup link */
 			if (!el.matches(this.swup.options.linkSelector)) return false;
-			/** Third, run all default checks */
+			/** Third, run the custom callback */
+			if (this.options.preloadVisibleLinks.ignore(el)) return false;
+			/** Fourth, run all default checks */
 			const { href } = Location.fromElement(el);
 			return this.shouldPreload(href, { el });
 		};


### PR DESCRIPTION
<!--
Thanks for creating this pull request!

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple PRs instead of opening a huge one.
-->

**Description**

<!--
Clear and concise description of the proposed changes, as well as a convincing reason for adding them to swup.
-->
Make the `preloadVisibleLinks` and `preloadLinksOnAttention` methods check the `data-swup-no-preload` attribute. If it exists, skip preloading for that link.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `main` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] New or updated tests are included
- [ ] The documentation was updated as required

**Additional information**

<!--
Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.
-->
